### PR TITLE
Implement Llama, Mistral, and GPT-NeoX transformer variants.

### DIFF
--- a/penzai/experimental/v2/models/transformer/variants/gpt_neox.py
+++ b/penzai/experimental/v2/models/transformer/variants/gpt_neox.py
@@ -1,0 +1,549 @@
+# Copyright 2024 The Penzai Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Transformer variant for GPT-NeoX models.
+
+The GPT-NeoX architecture is used by the GPT-NeoX-20B model (Black et al., 2022)
+and the Pythia model scaling suite (Biderman et al., 2023).
+
+Features of the architecture:
+
+- Full multi-head attention
+- Rotary positional embeddings (Su et al., 2021), but only applied to a subset
+  of positions,
+- Parallel Transformer layer formulation (Wang & Komatsuzaki, 2021)
+- Biases for all kernels
+
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import functools
+from typing import Any, Literal
+
+import jax
+import jax.numpy as jnp
+from penzai.experimental.v2 import pz
+from penzai.experimental.v2.models.transformer import model_parts
+
+
+@dataclasses.dataclass
+class GPTNeoXTransformerConfig:
+  """Configuration parameters for a GPT Neo-X transformer.
+
+  These are held in a single configuration object to simplify argument passing
+  during construction of the model.
+
+  Attributes:
+    num_attention_heads: The number of attention heads.
+    embedding_dim: Dimension of the embedding vectors and residual stream.
+    projection_dim: Dimension of the query, key, and value projections. Usually
+      ``embedding_dim // num_heads``.
+    mlp_hidden_dim: Dimensionality of the hidden layer of the MLP blocks in each
+      layer (the "neurons" axis).
+    num_decoder_blocks: Number of transformer decoder blocks in the model.
+    vocab_size: Number of tokens in the vocabulary.
+    activation_fn: Activation function
+    rope_subset_size: Number of projection dimensions to allocate to rotary
+      position embeddings.
+    rope_wavelength: Wavelength for RoPE layers.
+    layernorm_epsilon: Epsilon for layer normalization layers.
+    parameter_dtype: Floating dtype to use for all parameters.
+    activation_dtype: Floating dtype to use for activations and KV cache tables.
+    use_layer_stack: Whether to stack the blocks together using a LayerStack.
+  """
+
+  num_attention_heads: int
+  embedding_dim: int
+  projection_dim: int
+  mlp_hidden_dim: int
+  num_decoder_blocks: int
+  vocab_size: int
+  activation_fn: Literal["relu", "selu", "gelu_exact", "gelu_approx"]
+  rope_subset_size: int
+  rope_wavelength: float
+  layernorm_epsilon: float
+  parameter_dtype: jax.typing.DTypeLike
+  activation_dtype: jax.typing.DTypeLike
+  use_layer_stack: bool = False
+
+
+def build_gpt_neox_feedforward(
+    name: str,
+    init_base_rng: jax.Array | None,
+    config: GPTNeoXTransformerConfig,
+) -> model_parts.TransformerFeedForward:
+  """Creates a feedforward block.
+
+  The GPT-NeoX model uses a standard MLP configuration.
+
+  Args:
+    name: Name of the feedforward block.
+    init_base_rng: Base RNG for initializing the parameters.
+    config: The configuration of the model.
+
+  Returns:
+    An instance of TransformerFeedForward containing the MLP.
+  """
+  act_fn = {
+      "gelu_exact": functools.partial(jax.nn.gelu, approximate=False),
+      "gelu_approx": functools.partial(jax.nn.gelu, approximate=True),
+      "silu": jax.nn.silu,
+      "relu": jax.nn.relu,
+  }[config.activation_fn]
+  return model_parts.TransformerFeedForward([
+      pz.nn.Affine.from_config(
+          name=f"{name}/in",
+          init_base_rng=init_base_rng,
+          input_axes={"embedding": config.embedding_dim},
+          output_axes={"neurons": config.mlp_hidden_dim},
+      ),
+      pz.nn.Elementwise(act_fn),
+      pz.nn.Affine.from_config(
+          name=f"{name}/out",
+          init_base_rng=init_base_rng,
+          input_axes={"neurons": config.mlp_hidden_dim},
+          output_axes={"embedding": config.embedding_dim},
+      ),
+  ])
+
+
+def build_gpt_neox_attention(
+    name: str,
+    init_base_rng: jax.Array | None,
+    config: GPTNeoXTransformerConfig,
+) -> pz.nn.Attention:
+  """Builds an attention block from a configuration.
+
+  Args:
+    name: Name of the attention block.
+    init_base_rng: Base RNG for initializing the parameters.
+    config: The configuration of the model.
+
+  Returns:
+    An Attention block.
+  """
+  num_heads = config.num_attention_heads
+  embedding_dim = config.embedding_dim
+  projection_dim = config.projection_dim
+
+  # As used in https://github.com/google-deepmind/gemma.
+  # (This exact value is probably not important.)
+  masked_out_value = jnp.array(-2.3819763e38, dtype=config.activation_dtype)
+
+  return pz.nn.Attention(
+      input_to_query=pz.nn.Sequential([
+          pz.nn.Affine.from_config(
+              name=f"{name}/query",
+              init_base_rng=init_base_rng,
+              input_axes={"embedding": embedding_dim},
+              output_axes={"heads": num_heads, "projection": projection_dim},
+              dtype=config.parameter_dtype,
+          ),
+          pz.nn.ApplyRoPEToSubset(
+              positions_input_name="token_positions",
+              embedding_axis="projection",
+              max_wavelength=config.rope_wavelength,
+              rope_subset_size=config.rope_subset_size,
+          ),
+          pz.nn.ConstantRescale(
+              by=jnp.array(projection_dim**-0.5, dtype=config.activation_dtype)
+          ),
+      ]),
+      input_to_key=pz.nn.Sequential([
+          pz.nn.Affine.from_config(
+              name=f"{name}/key",
+              init_base_rng=init_base_rng,
+              input_axes={"embedding": embedding_dim},
+              output_axes={"heads": num_heads, "projection": projection_dim},
+              dtype=config.parameter_dtype,
+          ),
+          pz.nn.ApplyRoPEToSubset(
+              positions_input_name="token_positions",
+              embedding_axis="projection",
+              max_wavelength=config.rope_wavelength,
+              rope_subset_size=config.rope_subset_size,
+          ),
+      ]),
+      input_to_value=pz.nn.Sequential([
+          pz.nn.Affine.from_config(
+              name=f"{name}/value",
+              init_base_rng=init_base_rng,
+              input_axes={"embedding": embedding_dim},
+              output_axes={"heads": num_heads, "projection": projection_dim},
+              dtype=config.parameter_dtype,
+          ),
+      ]),
+      query_key_to_attn=pz.nn.Sequential([
+          pz.nn.NamedEinsum(
+              (
+                  {"seq": "tq", "heads": "h", "projection": "p"},
+                  {"seq": "tkv", "heads": "h", "projection": "p"},
+              ),
+              {"seq": "tq", "heads": "h", "kv_seq": "tkv"},
+          ),
+          pz.nn.ApplyAttentionMask(
+              mask_input_name="attn_mask",
+              masked_out_value=masked_out_value,
+          ),
+          pz.nn.Softmax("kv_seq"),
+      ]),
+      attn_value_to_output=pz.nn.Sequential([
+          pz.nn.NamedEinsum(
+              (
+                  {"seq": "tq", "heads": "h", "kv_seq": "tkv"},
+                  {"seq": "tkv", "heads": "h", "projection": "p"},
+              ),
+              {"seq": "tq", "heads": "h", "projection": "p"},
+          ),
+          pz.nn.Affine.from_config(
+              name=f"{name}/output",
+              init_base_rng=init_base_rng,
+              input_axes={"heads": num_heads, "projection": projection_dim},
+              output_axes={"embedding": embedding_dim},
+              dtype=config.parameter_dtype,
+          ),
+      ]),
+  )
+
+
+def build_gpt_neox_block(
+    name: str,
+    init_base_rng: jax.Array | None,
+    config: GPTNeoXTransformerConfig,
+) -> model_parts.TransformerBlock:
+  """Builds a GPT-NeoX "parallel" transformer block from a configuration.
+
+  GPT-NeoX uses a parallel formulation of transformer blocks, where the input of
+  the previous block is fed to the attention and feedforward components at the
+  same time:
+
+    y = x + MLP(LayerNorm(x)) + Attention(LayerNorm(x))
+
+  Args:
+    name: Name of the block.
+    init_base_rng: Base RNG for initializing the parameters.
+    config: The configuration of the model.
+
+  Returns:
+    A full transformer block.
+  """
+  return model_parts.TransformerBlock(
+      sublayers=[
+          pz.nn.BranchAndAddTogether([
+              pz.nn.Identity(),
+              pz.nn.Sequential([
+                  pz.nn.LayerNorm.from_config(
+                      name=f"{name}/pre_attention_norm",
+                      init_base_rng=init_base_rng,
+                      across_axes={"embedding": config.embedding_dim},
+                      epsilon=config.layernorm_epsilon,
+                      dtype=config.parameter_dtype,
+                  ),
+                  build_gpt_neox_attention(
+                      f"{name}/attention", init_base_rng, config
+                  ),
+              ]),
+              pz.nn.Sequential([
+                  pz.nn.LayerNorm.from_config(
+                      name=f"{name}/pre_ffw_norm",
+                      init_base_rng=init_base_rng,
+                      across_axes={"embedding": config.embedding_dim},
+                      epsilon=config.layernorm_epsilon,
+                      dtype=config.parameter_dtype,
+                  ),
+                  build_gpt_neox_feedforward(
+                      f"{name}/mlp", init_base_rng, config
+                  ),
+              ]),
+          ])
+      ],
+  )
+
+
+def build_gpt_neox_transformer(
+    config: GPTNeoXTransformerConfig,
+    init_base_rng: jax.Array | None = None,
+    name: str = "transformer",
+) -> model_parts.Transformer:
+  """Builds a Llama-like transformer model from a configuration.
+
+  Args:
+    config: The configuration of the model.
+    init_base_rng: Base RNG for initializing the parameters.
+    name: Name for the top-level model, used as a prefix for all parameters.
+
+  Returns:
+    A full transformer model.
+  """
+
+  # Embedding table is shared between first and last layers.
+  emb_table = pz.nn.EmbeddingTable.from_config(
+      name=f"{name}/embedder",
+      init_base_rng=init_base_rng,
+      vocab_size=config.vocab_size,
+      embedding_axes={"embedding": config.embedding_dim},
+      dtype=config.parameter_dtype,
+  )
+  sublayers = []
+  sublayers.append(pz.nn.EmbeddingLookup(emb_table))
+  if config.activation_dtype != config.parameter_dtype:
+    sublayers.append(pz.nn.CastToDType(config.activation_dtype))
+
+  if config.use_layer_stack:
+    sublayers.append(
+        pz.nn.LayerStack.from_sublayer_builder(
+            builder=build_gpt_neox_block,
+            stack_axis="blocks",
+            stack_axis_size=config.num_decoder_blocks,
+            init_base_rng=init_base_rng,
+            builder_kwargs=dict(name=f"{name}/blocks", config=config),
+        )
+    )
+  else:
+    for i in range(config.num_decoder_blocks):
+      sublayers.append(
+          build_gpt_neox_block(f"{name}/block_{i}", init_base_rng, config)
+      )
+
+  sublayers.append(
+      pz.nn.LayerNorm.from_config(
+          name=f"{name}/final_norm",
+          init_base_rng=init_base_rng,
+          across_axes={"embedding": config.embedding_dim},
+          dtype=config.parameter_dtype,
+      )
+  )
+
+  sublayers.append(
+      pz.nn.Linear.from_config(
+          name=f"{name}/lm_head",
+          init_base_rng=init_base_rng,
+          input_axes={"embedding": config.embedding_dim},
+          output_axes={"vocabulary": config.vocab_size},
+      )
+  )
+
+  return model_parts.Transformer(
+      metadata=model_parts.TransformerMetadata(
+          common_head_axes={"heads": config.num_attention_heads},
+          query_only_head_axes={},
+          embedding_dim=config.embedding_dim,
+          projection_dim=config.projection_dim,
+          mlp_hidden_dim=config.mlp_hidden_dim,
+          vocab_size=config.vocab_size,
+          activation_dtype=config.activation_dtype,
+      ),
+      body=pz.nn.Sequential(sublayers),
+  )
+
+
+GPTNeoXForCausalLM = Any
+
+
+def gpt_neox_from_huggingface_model(
+    model: GPTNeoXForCausalLM,
+    upcast_activations_to_float32: bool = False,
+    use_layer_stack: bool = False,
+) -> model_parts.Transformer:
+  """Converts a GPT-NeoX model to a Penzai model.
+
+  This function converts GPT-NeoX models from their HuggingFace implementations
+  to Penzai.
+
+  Note: Checkpoint conversion is only implemented for the most common set of
+  hyperparameters for GPT-NeoX models, including GPT-NeoX-20B and the Pythia
+  scaling suite.
+
+  Args:
+    model: The HuggingFace Llama or Mistral model.
+    upcast_activations_to_float32: Whether to cast activations to float32 when
+      the model runs. This allows analyzing activations at higher precision
+      without consuming additional memory for parameters.
+    use_layer_stack: Whether to use a layer stack for the decoder blocks.
+
+  Returns:
+    A Transformer model containing the loaded parameters.
+  """
+  # Checkpoint conversion assumes these configuration arguments are set:
+  hf_config = model.config
+  checked_config_args = dict(
+      use_parallel_residual=True,
+      rope_scaling=None,
+      attention_bias=True,
+      attention_dropout=0.0,
+      hidden_dropout=0.0,
+  )
+  for k, v in checked_config_args.items():
+    actual_value = getattr(hf_config, k)
+    if actual_value != v:
+      raise ValueError(
+          f"Conversion of a GPTNeoXForCausalLM requires config.{k}={repr(v)},"
+          f" but got {actual_value}"
+      )
+
+  param_dtype = {
+      "torch.float32": jnp.float32,
+      "torch.bfloat16": jnp.bfloat16,
+  }[str(model.dtype)]
+  if upcast_activations_to_float32:
+    activation_dtype = jnp.float32
+  else:
+    activation_dtype = param_dtype
+
+  projection_dim = hf_config.hidden_size // hf_config.num_attention_heads
+  converted_activation_fn = {
+      "gelu": "gelu_exact",
+      "gelu_new": "gelu_approx",
+      "relu": "relu",
+      "silu": "silu",
+  }[hf_config.hidden_act]
+  pz_config = GPTNeoXTransformerConfig(
+      num_attention_heads=hf_config.num_attention_heads,
+      embedding_dim=hf_config.hidden_size,
+      projection_dim=projection_dim,
+      mlp_hidden_dim=hf_config.intermediate_size,
+      num_decoder_blocks=hf_config.num_hidden_layers,
+      vocab_size=hf_config.vocab_size,
+      activation_fn=converted_activation_fn,
+      rope_wavelength=hf_config.rotary_emb_base,
+      rope_subset_size=int(hf_config.rotary_pct * projection_dim),
+      layernorm_epsilon=hf_config.layer_norm_eps,
+      parameter_dtype=param_dtype,
+      activation_dtype=activation_dtype,
+      use_layer_stack=use_layer_stack,
+  )
+  model_def = build_gpt_neox_transformer(
+      pz_config, init_base_rng=None, name="transformer"
+  )
+
+  state_dict = model.state_dict()
+  converted = {k: jax.dlpack.from_dlpack(v) for k, v in state_dict.items()}
+
+  parameter_mapping = {
+      "embedder.embeddings": pz.nx.NamedArray.wrap(
+          converted["gpt_neox.embed_in.weight"]
+      ).tag("vocabulary", "embedding"),
+      "final_norm/scale.weights": pz.nx.NamedArray.wrap(
+          converted["gpt_neox.final_layer_norm.weight"]
+      ).tag("embedding"),
+      "final_norm/shift.bias": pz.nx.NamedArray.wrap(
+          converted["gpt_neox.final_layer_norm.bias"]
+      ).tag("embedding"),
+      "lm_head.weights": pz.nx.NamedArray.wrap(
+          converted["embed_out.weight"]
+      ).tag("vocabulary", "embedding"),
+  }
+
+  all_block_params = []
+
+  for i in range(pz_config.num_decoder_blocks):
+    cur_block_params = {}
+    all_block_params.append(cur_block_params)
+
+    cur_block_params["pre_attention_norm/scale.weights"] = (
+        pz.nx.NamedArray.wrap(
+            converted[f"gpt_neox.layers.{i}.input_layernorm.weight"]
+        ).tag("embedding")
+    )
+    cur_block_params["pre_attention_norm/shift.bias"] = pz.nx.NamedArray.wrap(
+        converted[f"gpt_neox.layers.{i}.input_layernorm.bias"]
+    ).tag("embedding")
+    cur_block_params["pre_ffw_norm/scale.weights"] = pz.nx.NamedArray.wrap(
+        converted[f"gpt_neox.layers.{i}.post_attention_layernorm.weight"]
+    ).tag("embedding")
+    cur_block_params["pre_ffw_norm/shift.bias"] = pz.nx.NamedArray.wrap(
+        converted[f"gpt_neox.layers.{i}.post_attention_layernorm.bias"]
+    ).tag("embedding")
+    cur_block_params["mlp/in/Linear.weights"] = pz.nx.NamedArray.wrap(
+        converted[f"gpt_neox.layers.{i}.mlp.dense_h_to_4h.weight"]
+    ).tag("neurons", "embedding")
+    cur_block_params["mlp/in/AddBias.bias"] = pz.nx.NamedArray.wrap(
+        converted[f"gpt_neox.layers.{i}.mlp.dense_h_to_4h.bias"]
+    ).tag("neurons")
+    cur_block_params["mlp/out/Linear.weights"] = pz.nx.NamedArray.wrap(
+        converted[f"gpt_neox.layers.{i}.mlp.dense_4h_to_h.weight"]
+    ).tag("embedding", "neurons")
+    cur_block_params["mlp/out/AddBias.bias"] = pz.nx.NamedArray.wrap(
+        converted[f"gpt_neox.layers.{i}.mlp.dense_4h_to_h.bias"]
+    ).tag("embedding")
+
+    qkv_weights = (
+        pz.nx.NamedArray.wrap(
+            converted[f"gpt_neox.layers.{i}.attention.query_key_value.weight"]
+        )
+        .reshape((
+            pz_config.num_attention_heads,
+            3,
+            pz_config.projection_dim,
+            pz_config.embedding_dim,
+        ))
+        .tag("heads", "qkv", "projection", "embedding")
+    )
+    qkv_biases = (
+        pz.nx.NamedArray.wrap(
+            converted[f"gpt_neox.layers.{i}.attention.query_key_value.bias"]
+        )
+        .reshape((
+            pz_config.num_attention_heads,
+            3,
+            pz_config.projection_dim,
+        ))
+        .tag("heads", "qkv", "projection")
+    )
+
+    cur_block_params["attention/query/Linear.weights"] = qkv_weights[{"qkv": 0}]
+    cur_block_params["attention/key/Linear.weights"] = qkv_weights[{"qkv": 1}]
+    cur_block_params["attention/value/Linear.weights"] = qkv_weights[{"qkv": 2}]
+    cur_block_params["attention/query/AddBias.bias"] = qkv_biases[{"qkv": 0}]
+    cur_block_params["attention/key/AddBias.bias"] = qkv_biases[{"qkv": 1}]
+    cur_block_params["attention/value/AddBias.bias"] = qkv_biases[{"qkv": 2}]
+
+    cur_block_params["attention/output/Linear.weights"] = (
+        pz.nx.NamedArray.wrap(
+            converted[f"gpt_neox.layers.{i}.attention.dense.weight"]
+        )
+        .reshape((
+            pz_config.embedding_dim,
+            pz_config.num_attention_heads,
+            pz_config.projection_dim,
+        ))
+        .tag("embedding", "heads", "projection")
+    )
+    cur_block_params["attention/output/AddBias.bias"] = pz.nx.NamedArray.wrap(
+        converted[f"gpt_neox.layers.{i}.attention.dense.bias"]
+    ).tag("embedding")
+
+  if use_layer_stack:
+    for key in all_block_params[0].keys():
+      vals = [
+          all_block_params[i][key] for i in range(pz_config.num_decoder_blocks)
+      ]
+      parameter_mapping[f"blocks/{key}"] = pz.nx.stack(vals, "blocks")
+  else:
+    for i in range(pz_config.num_decoder_blocks):
+      for key, value in all_block_params[i].items():
+        parameter_mapping[f"block_{i}/{key}"] = value
+
+  # Create parameter objects for each parameter.
+  model = pz.bind_variables(
+      model_def,
+      [
+          pz.Parameter(value=v, label=f"transformer/{k}")
+          for k, v in parameter_mapping.items()
+      ],
+  )
+  pz.nn.assert_no_parameter_slots(model)
+  return model

--- a/penzai/experimental/v2/models/transformer/variants/llama.py
+++ b/penzai/experimental/v2/models/transformer/variants/llama.py
@@ -1,0 +1,81 @@
+# Copyright 2024 The Penzai Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Llama architecture transformer variant."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+from penzai.experimental.v2 import pz
+from penzai.experimental.v2.models.transformer import model_parts
+from penzai.experimental.v2.models.transformer.variants import llamalike_common
+
+
+LlamaForCausalLM = Any
+
+
+def llama_from_huggingface_model(
+    model: LlamaForCausalLM,
+    upcast_activations_to_float32: bool = False,
+    use_layer_stack: bool = False,
+) -> model_parts.Transformer:
+  """Converts a HuggingFace Llama model to a Penzai model.
+
+  This function converts Llama models from their HuggingFace
+  implementations to Penzai. (Other models with the same architecture may also
+  be supported if they use the same configuration, but this has not been
+  tested.)
+
+  Args:
+    model: The HuggingFace Llama model.
+    upcast_activations_to_float32: Whether to cast activations to float32 when
+      the model runs. This allows analyzing activations at higher precision
+      without consuming additional memory for parameters.
+    use_layer_stack: Whether to use a layer stack for the decoder blocks.
+
+  Returns:
+    A Transformer model containing the loaded parameters.
+  """
+  if type(model).__name__ != "LlamaForCausalLM":
+    raise ValueError(
+        "llama_from_huggingface_model should be called with a"
+        f" LlamaForCausalLM instance, but got {type(model).__name__}."
+    )
+  # Checkpoint conversion assumes these configuration arguments are set:
+  hf_config = model.config
+  checked_config_args = dict(
+      hidden_act="silu",
+      rms_norm_eps=1e-6,
+      tie_word_embeddings=False,
+      rope_scaling=None,
+      attention_bias=False,
+      attention_dropout=0.0,
+      mlp_bias=False,
+  )
+  for k, v in checked_config_args.items():
+    actual_value = getattr(hf_config, k)
+    if actual_value != v:
+      raise ValueError(
+          f"Conversion of a LlamaForCausalLM requires config.{k}={repr(v)}, but"
+          f" got {actual_value}"
+      )
+
+  return llamalike_common.llamalike_from_huggingface_model(
+      model,
+      upcast_activations_to_float32=upcast_activations_to_float32,
+      use_layer_stack=use_layer_stack,
+  )

--- a/penzai/experimental/v2/models/transformer/variants/llamalike_common.py
+++ b/penzai/experimental/v2/models/transformer/variants/llamalike_common.py
@@ -1,0 +1,605 @@
+# Copyright 2024 The Penzai Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A common transformer family used by Llama, Mistral, Gemma, and other models.
+
+This module implements a transformer variant with:
+
+- GLU-based MLPs (SwiGLU or GeGLU) as introduced by Shazeer (2020),
+- Optional multi-query (Shazeer, 2019) or grouped-query (Ainslie et al. 2023)
+  attention,
+- Rotary positional embeddings (Su et al., 2021),
+- RMSNorm normalization (Zhang & Sennrich, 2019),
+- No biases in any dense kernels or layer norms.
+
+This family includes many popular open-weights models, including Llama, Mistral,
+Gemma, and Reka. It is also similar to the PaLM model architecture (but without
+"parallel" feedforward and attention blocks).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import functools
+from typing import Any, Literal
+
+import jax
+import jax.numpy as jnp
+from penzai.experimental.v2 import pz
+from penzai.experimental.v2.models.transformer import model_parts
+
+
+@dataclasses.dataclass
+class LLamalikeTransformerConfig:
+  """Common configuration parameters for a "llama-like" transformer.
+
+  These are held in a single configuration object to simplify argument passing
+  during construction of the model.
+
+  Attributes:
+    num_kv_heads: The number of key-value attention heads or head groups.
+    query_head_multiplier: The number of query heads for each KV head.
+    embedding_dim: Dimension of the embedding vectors and residual stream.
+    projection_dim: Dimension of the query, key, and value projections. Usually
+      ``embedding_dim // num_heads``.
+    mlp_hidden_dim: Dimensionality of the hidden layer of the MLP blocks in each
+      layer (the "neurons" axis).
+    num_decoder_blocks: Number of transformer decoder blocks in the model.
+    vocab_size: Number of tokens in the vocabulary.
+    mlp_variant: Gated linear unit variant for MLPs.
+    rope_wavelength: Wavelength for RoPE layers.
+    tie_embedder_and_logits: Whether to tie the weights of the input token
+      embedding and output logit layers. If True, also scales down input token
+      embeddings by sqrt(embedding_dim). (This is used by Gemma.)
+    parameter_dtype: Floating dtype to use for all parameters.
+    activation_dtype: Floating dtype to use for activations and KV cache tables.
+    use_layer_stack: Whether to stack the blocks together using a LayerStack.
+  """
+
+  num_kv_heads: int
+  query_head_multiplier: int
+  embedding_dim: int
+  projection_dim: int
+  mlp_hidden_dim: int
+  num_decoder_blocks: int
+  vocab_size: int
+  mlp_variant: Literal["geglu_approx", "swiglu"]
+  rope_wavelength: float
+  tie_embedder_and_logits: bool
+  parameter_dtype: jax.typing.DTypeLike
+  activation_dtype: jax.typing.DTypeLike
+  use_layer_stack: bool = False
+
+
+def build_llamalike_feedforward(
+    name: str,
+    init_base_rng: jax.Array | None,
+    config: LLamalikeTransformerConfig,
+) -> model_parts.TransformerFeedForward:
+  """Creates a feedforward block.
+
+  This family of models use gated linear units, as proposed by Shazeer (2020).
+  We represent this computation as a composition of simpler Penzai primitives,
+  to enable patching and post-processing of the various internal activations.
+
+  Args:
+    name: Name of the feedforward block.
+    init_base_rng: Base RNG for initializing the parameters.
+    config: The configuration of the model.
+
+  Returns:
+    An instance of TransformerFeedForward containing the GELU MLP blocks.
+  """
+  if config.mlp_variant == "geglu_approx":
+    # Approximate is already the default in JAX, but we specify it explicitly
+    # because defaults differ between JAX and PyTorch.
+    act_fn = functools.partial(jax.nn.gelu, approximate=True)
+  elif config.mlp_variant == "swiglu":
+    act_fn = jax.nn.silu
+  else:
+    raise ValueError(f"Unsupported MLP variant {config.mlp_variant}")
+
+  return model_parts.TransformerFeedForward([
+      pz.nn.BranchAndMultiplyTogether(
+          branches=[
+              pz.nn.NamedGroup(
+                  "gate",
+                  [
+                      pz.nn.Linear.from_config(
+                          name=f"{name}/gating_linear",
+                          init_base_rng=init_base_rng,
+                          input_axes={"embedding": config.embedding_dim},
+                          output_axes={"neurons": config.mlp_hidden_dim},
+                          dtype=config.parameter_dtype,
+                      ),
+                      pz.nn.Elementwise(act_fn),
+                  ],
+              ),
+              pz.nn.Linear.from_config(
+                  name=f"{name}/value_linear",
+                  init_base_rng=init_base_rng,
+                  input_axes={"embedding": config.embedding_dim},
+                  output_axes={"neurons": config.mlp_hidden_dim},
+                  dtype=config.parameter_dtype,
+              ),
+          ]
+      ),
+      pz.nn.Linear.from_config(
+          name=f"{name}/out_linear",
+          init_base_rng=init_base_rng,
+          input_axes={"neurons": config.mlp_hidden_dim},
+          output_axes={"embedding": config.embedding_dim},
+          dtype=config.parameter_dtype,
+      ),
+  ])
+
+
+def _head_info(config: LLamalikeTransformerConfig):
+  if config.query_head_multiplier == 1:
+    common_head_axes = {"heads": config.num_kv_heads}
+    qkv_einsum = {"heads": "h"}
+    query_only_head_axes = {}
+    q_einsum = {}
+  elif config.num_kv_heads == 1:
+    common_head_axes = {}
+    qkv_einsum = {}
+    query_only_head_axes = {"query_heads": config.query_head_multiplier}
+    q_einsum = {"query_heads": "h"}
+  else:
+    common_head_axes = {"head_groups": config.num_kv_heads}
+    qkv_einsum = {"head_groups": "hg"}
+    query_only_head_axes = {"query_heads": config.query_head_multiplier}
+    q_einsum = {"query_heads": "hq"}
+  return (common_head_axes, qkv_einsum, query_only_head_axes, q_einsum)
+
+
+def build_llamalike_attention(
+    name: str,
+    init_base_rng: jax.Array | None,
+    config: LLamalikeTransformerConfig,
+) -> pz.nn.Attention:
+  """Builds an attention block from a configuration.
+
+  Args:
+    name: Name of the attention block.
+    init_base_rng: Base RNG for initializing the parameters.
+    config: The configuration of the model.
+
+  Returns:
+    An Attention block.
+  """
+  embedding_dim = config.embedding_dim
+  projection_dim = config.projection_dim
+
+  common_head_axes, qkv_einsum, query_only_head_axes, q_einsum = _head_info(
+      config
+  )
+
+  # As used in https://github.com/google-deepmind/gemma.
+  # (This exact value is probably not important.)
+  masked_out_value = jnp.array(-2.3819763e38, dtype=config.activation_dtype)
+
+  return pz.nn.Attention(
+      input_to_query=pz.nn.Sequential([
+          pz.nn.Linear.from_config(
+              name=f"{name}/query",
+              init_base_rng=init_base_rng,
+              input_axes={"embedding": embedding_dim},
+              output_axes={
+                  **common_head_axes,
+                  **query_only_head_axes,
+                  "projection": projection_dim,
+              },
+              dtype=config.parameter_dtype,
+          ),
+          pz.nn.ApplyRoPE(
+              positions_input_name="token_positions",
+              embedding_axis="projection",
+              max_wavelength=config.rope_wavelength,
+          ),
+          pz.nn.ConstantRescale(
+              by=jnp.array(projection_dim**-0.5, dtype=config.activation_dtype)
+          ),
+      ]),
+      input_to_key=pz.nn.Sequential([
+          pz.nn.Linear.from_config(
+              name=f"{name}/key",
+              init_base_rng=init_base_rng,
+              input_axes={"embedding": embedding_dim},
+              output_axes={**common_head_axes, "projection": projection_dim},
+              dtype=config.parameter_dtype,
+          ),
+          pz.nn.ApplyRoPE(
+              positions_input_name="token_positions",
+              embedding_axis="projection",
+              max_wavelength=config.rope_wavelength,
+          ),
+      ]),
+      input_to_value=pz.nn.Sequential([
+          pz.nn.Linear.from_config(
+              name=f"{name}/value",
+              init_base_rng=init_base_rng,
+              input_axes={"embedding": embedding_dim},
+              output_axes={**common_head_axes, "projection": projection_dim},
+              dtype=config.parameter_dtype,
+          ),
+      ]),
+      query_key_to_attn=pz.nn.Sequential([
+          pz.nn.NamedEinsum(
+              (
+                  {"seq": "tq", **qkv_einsum, **q_einsum, "projection": "p"},
+                  {"seq": "tkv", **qkv_einsum, "projection": "p"},
+              ),
+              {"seq": "tq", **qkv_einsum, **q_einsum, "kv_seq": "tkv"},
+          ),
+          pz.nn.ApplyAttentionMask(
+              mask_input_name="attn_mask",
+              masked_out_value=masked_out_value,
+          ),
+          pz.nn.Softmax("kv_seq"),
+      ]),
+      attn_value_to_output=pz.nn.Sequential([
+          pz.nn.NamedEinsum(
+              (
+                  {"seq": "tq", **qkv_einsum, **q_einsum, "kv_seq": "tkv"},
+                  {"seq": "tkv", **qkv_einsum, "projection": "p"},
+              ),
+              {"seq": "tq", **qkv_einsum, **q_einsum, "projection": "p"},
+          ),
+          pz.nn.Linear.from_config(
+              name=f"{name}/output",
+              init_base_rng=init_base_rng,
+              input_axes={
+                  **common_head_axes,
+                  **query_only_head_axes,
+                  "projection": projection_dim,
+              },
+              output_axes={"embedding": embedding_dim},
+              dtype=config.parameter_dtype,
+          ),
+      ]),
+  )
+
+
+def build_llamalike_block(
+    name: str,
+    init_base_rng: jax.Array | None,
+    config: LLamalikeTransformerConfig,
+) -> model_parts.TransformerBlock:
+  """Builds a transformer block from a configuration.
+
+  Args:
+    name: Name of the block.
+    init_base_rng: Base RNG for initializing the parameters.
+    config: The configuration of the model.
+
+  Returns:
+    A full transformer block.
+  """
+  return model_parts.TransformerBlock(
+      sublayers=[
+          pz.nn.Residual(
+              pz.nn.Sequential([
+                  pz.nn.RMSLayerNorm.from_config(
+                      name=f"{name}/pre_attention_norm",
+                      init_base_rng=init_base_rng,
+                      across_axes={"embedding": config.embedding_dim},
+                      dtype=config.parameter_dtype,
+                  ),
+                  build_llamalike_attention(
+                      f"{name}/attention", init_base_rng, config
+                  ),
+              ])
+          ),
+          pz.nn.Residual(
+              pz.nn.Sequential([
+                  pz.nn.RMSLayerNorm.from_config(
+                      name=f"{name}/pre_ffw_norm",
+                      init_base_rng=init_base_rng,
+                      across_axes={"embedding": config.embedding_dim},
+                      dtype=config.parameter_dtype,
+                  ),
+                  build_llamalike_feedforward(
+                      f"{name}/mlp", init_base_rng, config
+                  ),
+              ])
+          ),
+      ],
+  )
+
+
+def build_llamalike_transformer(
+    config: LLamalikeTransformerConfig,
+    init_base_rng: jax.Array | None = None,
+    name: str = "transformer",
+) -> model_parts.Transformer:
+  """Builds a Llama-like transformer model from a configuration.
+
+  Args:
+    config: The configuration of the model.
+    init_base_rng: Base RNG for initializing the parameters.
+    name: Name for the top-level model, used as a prefix for all parameters.
+
+  Returns:
+    A full transformer model.
+  """
+
+  # Embedding table is shared between first and last layers.
+  emb_table = pz.nn.EmbeddingTable.from_config(
+      name=f"{name}/embedder",
+      init_base_rng=init_base_rng,
+      vocab_size=config.vocab_size,
+      embedding_axes={"embedding": config.embedding_dim},
+      dtype=config.parameter_dtype,
+  )
+  sublayers = []
+  sublayers.append(pz.nn.EmbeddingLookup(emb_table))
+  if config.activation_dtype != config.parameter_dtype:
+    sublayers.append(pz.nn.CastToDType(config.activation_dtype))
+
+  if config.tie_embedder_and_logits:
+    sublayers.append(
+        pz.nn.ConstantRescale(
+            by=jnp.sqrt(config.embedding_dim).astype(config.activation_dtype)
+        )
+    )
+
+  if config.use_layer_stack:
+    sublayers.append(
+        pz.nn.LayerStack.from_sublayer_builder(
+            builder=build_llamalike_block,
+            stack_axis="blocks",
+            stack_axis_size=config.num_decoder_blocks,
+            init_base_rng=init_base_rng,
+            builder_kwargs=dict(name=f"{name}/blocks", config=config),
+        )
+    )
+  else:
+    for i in range(config.num_decoder_blocks):
+      sublayers.append(
+          build_llamalike_block(f"{name}/block_{i}", init_base_rng, config)
+      )
+
+  sublayers.append(
+      pz.nn.RMSLayerNorm.from_config(
+          name=f"{name}/final_norm",
+          init_base_rng=init_base_rng,
+          across_axes={"embedding": config.embedding_dim},
+          dtype=config.parameter_dtype,
+      )
+  )
+
+  if config.tie_embedder_and_logits:
+    sublayers.append(pz.nn.EmbeddingDecode(emb_table))
+  else:
+    sublayers.append(
+        pz.nn.Linear.from_config(
+            name=f"{name}/lm_head",
+            init_base_rng=init_base_rng,
+            input_axes={"embedding": config.embedding_dim},
+            output_axes={"vocabulary": config.vocab_size},
+        )
+    )
+
+  common_head_axes, _, query_only_head_axes, _ = _head_info(config)
+  return model_parts.Transformer(
+      metadata=model_parts.TransformerMetadata(
+          common_head_axes=common_head_axes,
+          query_only_head_axes=query_only_head_axes,
+          embedding_dim=config.embedding_dim,
+          projection_dim=config.projection_dim,
+          mlp_hidden_dim=config.mlp_hidden_dim,
+          vocab_size=config.vocab_size,
+          activation_dtype=config.activation_dtype,
+      ),
+      body=pz.nn.Sequential(sublayers),
+  )
+
+
+def llamalike_from_huggingface_model(
+    model: Any,
+    upcast_activations_to_float32: bool = False,
+    use_layer_stack: bool = False,
+) -> model_parts.Transformer:
+  """Converts a "llama-like" HuggingFace model to a Penzai model.
+
+  This function converts Llama-like models from their HuggingFace
+  implementations to Penzai. It does not do any checks and blindly assumes
+  that the architecture follows the defaults from the Llama model family.
+  You may want to use the model-specific wrappers in `variants.llama` or
+  `variants.mistral` instead.
+
+  Args:
+    model: The HuggingFace model, which is assumed to be similar to the Llama
+      or Mistral architectures. (Not all configuration arguments are checked,
+      so this may end up producing different behavior if given an incompatible
+      configuration.)
+    upcast_activations_to_float32: Whether to cast activations to float32 when
+      the model runs. This allows analyzing activations at higher precision
+      without consuming additional memory for parameters.
+    use_layer_stack: Whether to use a layer stack for the decoder blocks.
+
+  Returns:
+    A Transformer model containing the loaded parameters, assuming a Llama-like
+    architecture.
+  """
+  hf_config = model.config
+  num_kv_heads = hf_config.num_key_value_heads
+  query_head_multiplier = hf_config.num_attention_heads // num_kv_heads
+  assert num_kv_heads * query_head_multiplier == hf_config.num_attention_heads
+
+  param_dtype = {
+      "torch.float32": jnp.float32,
+      "torch.bfloat16": jnp.bfloat16,
+  }[str(model.dtype)]
+  if upcast_activations_to_float32:
+    activation_dtype = jnp.float32
+  else:
+    activation_dtype = param_dtype
+
+  pz_config = LLamalikeTransformerConfig(
+      num_kv_heads=num_kv_heads,
+      query_head_multiplier=query_head_multiplier,
+      embedding_dim=hf_config.hidden_size,
+      projection_dim=hf_config.hidden_size // hf_config.num_attention_heads,
+      mlp_hidden_dim=hf_config.intermediate_size,
+      num_decoder_blocks=hf_config.num_hidden_layers,
+      vocab_size=hf_config.vocab_size,
+      mlp_variant="swiglu",
+      rope_wavelength=10_000,
+      tie_embedder_and_logits=False,
+      parameter_dtype=param_dtype,
+      activation_dtype=activation_dtype,
+      use_layer_stack=use_layer_stack,
+  )
+  model_def = build_llamalike_transformer(
+      pz_config, init_base_rng=None, name="transformer"
+  )
+
+  state_dict = model.state_dict()
+  converted = {k: jax.dlpack.from_dlpack(v) for k, v in state_dict.items()}
+
+  parameter_mapping = {
+      "embedder.embeddings": pz.nx.NamedArray.wrap(
+          converted["model.embed_tokens.weight"]
+      ).tag("vocabulary", "embedding"),
+      "final_norm/scale.weights": pz.nx.NamedArray.wrap(
+          converted["model.norm.weight"]
+      ).tag("embedding"),
+      "lm_head.weights": pz.nx.NamedArray.wrap(converted["lm_head.weight"]).tag(
+          "vocabulary", "embedding"
+      ),
+  }
+
+  def fix_qkvo(which, arr):
+    arr = pz.nx.wrap(arr)
+    if which == "q":
+      if pz_config.query_head_multiplier == 1:
+        return arr.reshape((
+            pz_config.num_kv_heads,
+            pz_config.projection_dim,
+            pz_config.embedding_dim,
+        )).tag("heads", "projection", "embedding")
+      elif pz_config.num_kv_heads == 1:
+        return arr.reshape((
+            pz_config.query_head_multiplier,
+            pz_config.projection_dim,
+            pz_config.embedding_dim,
+        )).tag("query_heads", "projection", "embedding")
+      else:
+        return arr.reshape((
+            pz_config.num_kv_heads,
+            pz_config.query_head_multiplier,
+            pz_config.projection_dim,
+            pz_config.embedding_dim,
+        )).tag("head_groups", "query_heads", "projection", "embedding")
+    elif which == "k" or which == "v":
+      if pz_config.query_head_multiplier == 1:
+        return arr.reshape((
+            pz_config.num_kv_heads,
+            pz_config.projection_dim,
+            pz_config.embedding_dim,
+        )).tag("heads", "projection", "embedding")
+      elif pz_config.num_kv_heads == 1:
+        return arr.reshape((
+            pz_config.projection_dim,
+            pz_config.embedding_dim,
+        )).tag("projection", "embedding")
+      else:
+        return arr.reshape((
+            pz_config.num_kv_heads,
+            pz_config.projection_dim,
+            pz_config.embedding_dim,
+        )).tag("head_groups", "projection", "embedding")
+    elif which == "o":
+      if pz_config.query_head_multiplier == 1:
+        return arr.reshape((
+            pz_config.embedding_dim,
+            pz_config.num_kv_heads,
+            pz_config.projection_dim,
+        )).tag("embedding", "heads", "projection")
+      elif pz_config.num_kv_heads == 1:
+        return arr.reshape((
+            pz_config.embedding_dim,
+            pz_config.query_head_multiplier,
+            pz_config.projection_dim,
+        )).tag("embedding", "query_heads", "projection")
+      else:
+        return arr.reshape((
+            pz_config.embedding_dim,
+            pz_config.num_kv_heads,
+            pz_config.query_head_multiplier,
+            pz_config.projection_dim,
+        )).tag("embedding", "head_groups", "query_heads", "projection")
+    else:
+      raise NotImplementedError(which)
+
+  all_block_params = []
+
+  for i in range(pz_config.num_decoder_blocks):
+    cur_block_params = {}
+    all_block_params.append(cur_block_params)
+
+    cur_block_params["pre_attention_norm/scale.weights"] = (
+        pz.nx.NamedArray.wrap(
+            converted[f"model.layers.{i}.input_layernorm.weight"]
+        ).tag("embedding")
+    )
+    cur_block_params["pre_ffw_norm/scale.weights"] = pz.nx.NamedArray.wrap(
+        converted[f"model.layers.{i}.post_attention_layernorm.weight"]
+    ).tag("embedding")
+    cur_block_params["mlp/gating_linear.weights"] = pz.nx.NamedArray.wrap(
+        converted[f"model.layers.{i}.mlp.gate_proj.weight"]
+    ).tag("neurons", "embedding")
+    cur_block_params["mlp/value_linear.weights"] = pz.nx.NamedArray.wrap(
+        converted[f"model.layers.{i}.mlp.up_proj.weight"]
+    ).tag("neurons", "embedding")
+    cur_block_params["mlp/out_linear.weights"] = pz.nx.NamedArray.wrap(
+        converted[f"model.layers.{i}.mlp.down_proj.weight"]
+    ).tag("embedding", "neurons")
+
+    cur_block_params["attention/query.weights"] = fix_qkvo(
+        "q", converted[f"model.layers.{i}.self_attn.q_proj.weight"]
+    )
+    cur_block_params["attention/key.weights"] = fix_qkvo(
+        "k", converted[f"model.layers.{i}.self_attn.k_proj.weight"]
+    )
+    cur_block_params["attention/value.weights"] = fix_qkvo(
+        "v", converted[f"model.layers.{i}.self_attn.v_proj.weight"]
+    )
+    cur_block_params["attention/output.weights"] = fix_qkvo(
+        "o", converted[f"model.layers.{i}.self_attn.o_proj.weight"]
+    )
+
+  if use_layer_stack:
+    for key in all_block_params[0].keys():
+      vals = [
+          all_block_params[i][key] for i in range(pz_config.num_decoder_blocks)
+      ]
+      parameter_mapping[f"blocks/{key}"] = pz.nx.stack(vals, "blocks")
+  else:
+    for i in range(pz_config.num_decoder_blocks):
+      for key, value in all_block_params[i].items():
+        parameter_mapping[f"block_{i}/{key}"] = value
+
+  # Create parameter objects for each parameter.
+  model = pz.bind_variables(
+      model_def,
+      [
+          pz.Parameter(value=v, label=f"transformer/{k}")
+          for k, v in parameter_mapping.items()
+      ],
+  )
+  pz.nn.assert_no_parameter_slots(model)
+  return model

--- a/penzai/experimental/v2/models/transformer/variants/mistral.py
+++ b/penzai/experimental/v2/models/transformer/variants/mistral.py
@@ -1,0 +1,92 @@
+# Copyright 2024 The Penzai Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Mistral architecture transformer variant."""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+from penzai.experimental.v2 import pz
+from penzai.experimental.v2.models.transformer import model_parts
+from penzai.experimental.v2.models.transformer.variants import llamalike_common
+
+
+MistralForCausalLM = Any
+
+
+def mistral_from_huggingface_model(
+    model: MistralForCausalLM,
+    upcast_activations_to_float32: bool = False,
+    use_layer_stack: bool = False,
+) -> model_parts.Transformer:
+  """Converts a HuggingFace Mistral model to a Penzai model.
+
+  This function converts Mistral models from their HuggingFace
+  implementations to Penzai. (Other models with the same architecture may also
+  be supported if they use the same configuration, but this has not been
+  tested.)
+
+  Note: Mistral models use sliding window attention. Penzai does not compute
+  this attention mask automatically, so you will have to manually adjust the
+  mask if using an input longer than Mistral's sliding window. (Additionally,
+  the KV-cache logic does not currently support sliding-window attention.)
+
+  Args:
+    model: The HuggingFace Mistral model.
+    upcast_activations_to_float32: Whether to cast activations to float32 when
+      the model runs. This allows analyzing activations at higher precision
+      without consuming additional memory for parameters.
+    use_layer_stack: Whether to use a layer stack for the decoder blocks.
+
+  Returns:
+    A Transformer model containing the loaded parameters.
+  """
+  if type(model).__name__ != "MistralForCausalLM":
+    raise ValueError(
+        "mistral_from_huggingface_model should be called with a"
+        f" MistralForCausalLM instance, but got {type(model).__name__}."
+    )
+  # Checkpoint conversion assumes these configuration arguments are set:
+  hf_config = model.config
+  checked_config_args = dict(
+      hidden_act="silu",
+      rms_norm_eps=1e-6,
+      tie_word_embeddings=False,
+      attention_dropout=0.0,
+  )
+  for k, v in checked_config_args.items():
+    actual_value = getattr(hf_config, k)
+    if actual_value != v:
+      raise ValueError(
+          f"Conversion of a LlamaForCausalLM requires config.{k}={repr(v)}, but"
+          f" got {actual_value}"
+      )
+
+  if model.config.sliding_window is not None:
+    warnings.warn(
+        "Sliding window attention is not directly supported in Penzai. Training"
+        " or scoring mode should work with a manually-constructed attention"
+        " mask, but decoding may not work correctly in key-value cache"
+        " decoding mode!"
+    )
+
+  return llamalike_common.llamalike_from_huggingface_model(
+      model,
+      upcast_activations_to_float32=upcast_activations_to_float32,
+      use_layer_stack=use_layer_stack,
+  )

--- a/penzai/experimental/v2/pz/nn.py
+++ b/penzai/experimental/v2/pz/nn.py
@@ -41,6 +41,7 @@ from penzai.experimental.v2.nn.embeddings import (
     EmbeddingLookup,
     EmbeddingDecode,
     ApplyRoPE,
+    ApplyRoPEToSubset,
 )
 from penzai.experimental.v2.nn.grouping import (
     CheckedSequential,

--- a/penzai/experimental/v2/toolshed/save_intermediates.py
+++ b/penzai/experimental/v2/toolshed/save_intermediates.py
@@ -110,7 +110,7 @@ def saving_all_intermediates(
           pz.select(cur_layer)
           .at_children()
           .at_instances_of(pz.nn.Layer)
-          .apply(add_intercept_values_inside)
+          .apply(add_intercept_values_around)
       )
 
   def add_intercept_values_around(cur_layer: pz.nn.Layer) -> pz.nn.Layer:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ extras = [
     "ipython",
     "flax>=0.8.2",
     "optax",
+    "torch",
+    "transformers>=4.41.2",
 ]
 # Extra dependencies for some notebook demos.
 notebook = [

--- a/tests/experimental/models/transformer_consistency_test.py
+++ b/tests/experimental/models/transformer_consistency_test.py
@@ -1,0 +1,154 @@
+# Copyright 2024 The Penzai Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for consistency between official and Penzai model implementations."""
+
+import warnings
+
+from absl.testing import absltest
+from absl.testing import parameterized
+import chex
+import jax.numpy as jnp
+import numpy as np
+import torch
+import transformers
+
+from penzai.experimental.v2 import pz
+from penzai.experimental.v2.models.transformer.variants import llama
+from penzai.experimental.v2.models.transformer.variants import mistral
+from penzai.experimental.v2.models.transformer.variants import gpt_neox
+
+
+class TransformerConsistencyTest(parameterized.TestCase):
+
+  @parameterized.named_parameters(
+      dict(testcase_name="full", num_attention_heads=4, num_key_value_heads=4),
+      dict(testcase_name="mqa", num_attention_heads=4, num_key_value_heads=1),
+      dict(testcase_name="gqa", num_attention_heads=4, num_key_value_heads=2),
+  )
+  def test_llama_consistency(self, num_attention_heads, num_key_value_heads):
+    cfg = transformers.LlamaConfig(
+        vocab_size=11,
+        hidden_size=64,
+        intermediate_size=256,
+        num_hidden_layers=3,
+        num_attention_heads=num_attention_heads,
+        num_key_value_heads=num_key_value_heads,
+    )
+
+    torch.manual_seed(0)
+    hf_model = transformers.LlamaForCausalLM(cfg)
+
+    tokens = pz.nx.wrap(jnp.tile(jnp.arange(11), 3)[None, :], "batch", "seq")
+
+    hf_arg = torch.tensor(np.array(tokens.unwrap("batch", "seq")))
+    hf_out = pz.nx.wrap(hf_model(hf_arg).logits.detach().numpy()).tag(
+        "batch", "seq", "vocabulary"
+    )
+
+    for layer_stack in (False, True):
+      with self.subTest(f"layer_stack={layer_stack}"):
+        pz_model = llama.llama_from_huggingface_model(
+            hf_model, use_layer_stack=layer_stack
+        )
+
+        side_inputs = pz_model.simple_causal_side_inputs(tokens)
+        pz_out = pz_model(tokens, **side_inputs)
+
+        chex.assert_trees_all_close(
+            pz_out, hf_out.order_like(pz_out), atol=1e-6
+        )
+
+  @parameterized.named_parameters(
+      dict(testcase_name="full", num_attention_heads=4, num_key_value_heads=4),
+      dict(testcase_name="mqa", num_attention_heads=4, num_key_value_heads=1),
+      dict(testcase_name="gqa", num_attention_heads=4, num_key_value_heads=2),
+  )
+  def test_mistral_consistency(self, num_attention_heads, num_key_value_heads):
+    cfg = transformers.MistralConfig(
+        vocab_size=11,
+        hidden_size=64,
+        intermediate_size=256,
+        num_hidden_layers=3,
+        num_attention_heads=num_attention_heads,
+        num_key_value_heads=num_key_value_heads,
+    )
+
+    torch.manual_seed(0)
+    hf_model = transformers.MistralForCausalLM(cfg)
+
+    tokens = pz.nx.wrap(jnp.tile(jnp.arange(11), 3)[None, :], "batch", "seq")
+
+    hf_arg = torch.tensor(np.array(tokens.unwrap("batch", "seq")))
+    hf_out = pz.nx.wrap(hf_model(hf_arg).logits.detach().numpy()).tag(
+        "batch", "seq", "vocabulary"
+    )
+
+    for layer_stack in (False, True):
+      with self.subTest(f"layer_stack={layer_stack}"):
+        with warnings.catch_warnings(record=True) as recorded:
+          pz_model = mistral.mistral_from_huggingface_model(
+              hf_model, use_layer_stack=layer_stack
+          )
+
+        self.assertLen(recorded, 1)
+        self.assertStartsWith(
+            str(recorded[0].message),
+            "Sliding window attention is not directly supported in Penzai.",
+        )
+
+        side_inputs = pz_model.simple_causal_side_inputs(tokens)
+        pz_out = pz_model(tokens, **side_inputs)
+
+        chex.assert_trees_all_close(
+            pz_out, hf_out.order_like(pz_out), atol=1e-6
+        )
+
+  def test_gpt_neox_consistency(self):
+    cfg = transformers.GPTNeoXConfig(
+        vocab_size=11,
+        hidden_size=64,
+        intermediate_size=256,
+        num_hidden_layers=3,
+        num_attention_heads=4,
+    )
+
+    torch.manual_seed(0)
+    hf_model = transformers.GPTNeoXForCausalLM(cfg)
+
+    tokens = pz.nx.wrap(jnp.tile(jnp.arange(11), 3)[None, :], "batch", "seq")
+
+    hf_arg = torch.tensor(np.array(tokens.unwrap("batch", "seq")))
+    hf_out = pz.nx.wrap(hf_model(hf_arg).logits.detach().numpy()).tag(
+        "batch", "seq", "vocabulary"
+    )
+
+    for layer_stack in (False, True):
+      with self.subTest(f"layer_stack={layer_stack}"):
+        pz_model = gpt_neox.gpt_neox_from_huggingface_model(
+            hf_model, use_layer_stack=layer_stack
+        )
+        side_inputs = pz_model.simple_causal_side_inputs(tokens)
+        pz_out = pz_model(tokens, **side_inputs)
+
+        chex.assert_trees_all_close(
+            pz_out, hf_out.order_like(pz_out), atol=1e-3
+        )
+        chex.assert_trees_all_close(
+            pz_out, hf_out.order_like(pz_out), rtol=3e-3
+        )
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
Adds support for Llama, Mistral, and GPT-NeoX transformer models. These models can be converted from their corresponding pretrained model classes from HuggingFace's `transformers` library (the `XForCausalLM` classes).

Also adds tests to ensure that the converted versions are consistent with the HuggingFace implementations.