### PR TITLE
More informative structure mismatch error message in Linear layer

### DIFF
--- a/penzai/nn/linear_and_affine.py
+++ b/penzai/nn/linear_and_affine.py
@@ -421,12 +421,12 @@ class Linear(layer_base.Layer):
   def __call__(self, in_array: NamedArray, **_unused_side_inputs) -> NamedArray:
     """Runs the linear operator."""
     in_struct = self._input_structure()
-    dimvars = shapecheck.check_structure(in_array, in_struct)
+    dimvars = shapecheck.check_structure(in_array, in_struct, error_prefix=f"({self.weights.label[:-8]}) ")
 
     result = contract(self.in_axis_names, in_array, self.weights.value)
 
     out_struct = self._output_structure()
-    shapecheck.check_structure(result, out_struct, known_vars=dimvars)
+    shapecheck.check_structure(result, out_struct, known_vars=dimvars, error_prefix=f"({self.weights.label[:-8]}) ")
     return result
 
   @classmethod

--- a/penzai/nn/linear_and_affine.py
+++ b/penzai/nn/linear_and_affine.py
@@ -424,6 +424,8 @@ class Linear(layer_base.Layer):
   def __call__(self, in_array: NamedArray, **_unused_side_inputs) -> NamedArray:
     """Runs the linear operator."""
     in_struct = self._input_structure()
+
+    # pytype: disable=attribute-error
     if isinstance(
         self.weights,
         Parameter | ParameterValue,
@@ -431,6 +433,7 @@ class Linear(layer_base.Layer):
       error_prefix = f"({self.weights.label[:-8]}) "
     else:
       error_prefix = ""
+    # pytype: enable=attribute-error
 
     dimvars = shapecheck.check_structure(
         in_array, in_struct, error_prefix=error_prefix

--- a/penzai/nn/linear_and_affine.py
+++ b/penzai/nn/linear_and_affine.py
@@ -27,11 +27,14 @@ import jax.numpy as jnp
 from penzai.core import named_axes
 from penzai.core import shapecheck
 from penzai.core import struct
+from penzai.core import variables
 from penzai.nn import grouping
 from penzai.nn import layer as layer_base
 from penzai.nn import parameters
 
 NamedArray = named_axes.NamedArray
+Parameter = variables.Parameter
+ParameterValue = variables.ParameterValue
 
 
 class LinearOperatorWeightInitializer(Protocol):
@@ -421,12 +424,24 @@ class Linear(layer_base.Layer):
   def __call__(self, in_array: NamedArray, **_unused_side_inputs) -> NamedArray:
     """Runs the linear operator."""
     in_struct = self._input_structure()
-    dimvars = shapecheck.check_structure(in_array, in_struct, error_prefix=f"({self.weights.label[:-8]}) ")
+    if isinstance(
+        self.weights,
+        Parameter | ParameterValue,
+    ) and self.weights.label.endswith(".weights"):
+      error_prefix = f"({self.weights.label[:-8]}) "
+    else:
+      error_prefix = ""
+
+    dimvars = shapecheck.check_structure(
+        in_array, in_struct, error_prefix=error_prefix
+    )
 
     result = contract(self.in_axis_names, in_array, self.weights.value)
 
     out_struct = self._output_structure()
-    shapecheck.check_structure(result, out_struct, known_vars=dimvars, error_prefix=f"({self.weights.label[:-8]}) ")
+    shapecheck.check_structure(
+        result, out_struct, known_vars=dimvars, error_prefix=error_prefix
+    )
     return result
 
   @classmethod


### PR DESCRIPTION
As mentioned in #89. With the following changes,

```python
from penzai import pz
import jax

linear = pz.nn.Linear.from_config("MyModel/MyComplexLayer/Linear_2", 
                                  jax.random.PRNGKey(0),
                                  input_axes={"feature": 3},
                                  output_axes={})

linear(pz.nx.ones({"feature": 4}))
```

will throw an error with information about the layer name: 

```
penzai.core.shapecheck.StructureMismatchError: (MyModel/MyComplexLayer/Linear_2) Mismatch while checking structures:
At root: Named shape mismatch between value {'feature': 4} and pattern {**var('B'), 'feature': 3}:
  Axis 'feature': Actual size 4 does not match expected 3
```

This makes it much easier to debug shape errors in complex models with many layers.
