### PR TITLE
Switch LayerStackGetAttrKey to a custom dataclass type.

### DIFF
--- a/penzai/core/tree_util.py
+++ b/penzai/core/tree_util.py
@@ -16,11 +16,22 @@
 
 from __future__ import annotations
 
+import dataclasses
 from typing import Any, Optional
 
 import jax
 
 PyTreeDef = jax.tree_util.PyTreeDef
+
+
+@dataclasses.dataclass(frozen=True)
+class CustomGetAttrKey:
+  """Subclass-friendly variant of jax.tree_util.GetAttrKey."""
+
+  name: str
+
+  def __str__(self):
+    return f".{self.name}"
 
 
 def tree_flatten_exactly_one_level(
@@ -66,7 +77,10 @@ def pretty_keystr(keypath: tuple[Any, ...], tree: Any) -> str:
   parts = []
   for key in keypath:
     if isinstance(
-        key, jax.tree_util.GetAttrKey | jax.tree_util.FlattenedIndexKey
+        key,
+        jax.tree_util.GetAttrKey
+        | jax.tree_util.FlattenedIndexKey
+        | CustomGetAttrKey,
     ):
       parts.extend(("/", type(tree).__name__))
     split = tree_flatten_exactly_one_level(tree)

--- a/penzai/nn/layer_stack.py
+++ b/penzai/nn/layer_stack.py
@@ -17,10 +17,11 @@
 from __future__ import annotations
 
 import collections
+from collections.abc import Hashable
 import copy
 import dataclasses
 import enum
-from typing import Any, Callable, Hashable
+from typing import Any, Callable
 
 import jax
 from penzai.core import named_axes
@@ -39,7 +40,7 @@ class LayerStackVarBehavior(enum.Enum):
 
 
 @dataclasses.dataclass(frozen=True)
-class LayerStackGetAttrKey(jax.tree_util.GetAttrKey):
+class LayerStackGetAttrKey(pz_tree_util.CustomGetAttrKey):
   """GetAttrKey for LayerStack with extra metadata.
 
   This allows us to identify whether a given PyTree leaf is contained inside a


### PR DESCRIPTION
This avoids subclassing JAX's `GetAttrKey`, which will be changing its implementation in the future.

This is an alternative to #93 which removes the dependencies on `GetAttrKey` instead of removing the dataclass decorator, so that the subclass can remain frozen and hashable.