### PR TITLE
Fix VSCode autoformat config to avoid bad Python version for pyink.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,6 +24,6 @@
         "editor.detectIndentation": false,
         "editor.defaultFormatter": "ms-python.black-formatter",
     },
-    "black-formatter.path": ["uvx", "pyink"],
+    "black-formatter.path": ["uvx", "--python=>=3.9,!=3.12.5", "pyink"],
     "pylint.enabled": true,
 }


### PR DESCRIPTION
Black and Pyink do not support python 3.12.5, but uvx automatically selects this version occasionally, which breaks autoformatting in VSCode.

See https://github.com/psf/black/blob/24.10.0/CHANGES.md for details.