### PR TITLE
Extends penzai to support gemma3 models.

### DIFF
--- a/docs/guides/howto_reference.md
+++ b/docs/guides/howto_reference.md
@@ -217,7 +217,7 @@ You can read more about Penzai's conventions for layers in ["How to Think in Pen
 
 ## Loading Pretrained Models
 
-### Loading Gemma or Gemma 2 or Gemma 3
+### Loading Gemma (1, 2, or 3)
 
 Penzai's Gemma implementation includes a conversion utility that converts the "Flax" model weights from Kaggle ([Gemma 1](https://www.kaggle.com/models/google/gemma), [Gemma 2](https://www.kaggle.com/models/google/gemma-2), [Gemma 3](https://www.kaggle.com/models/google/gemma-3)) into the correct form. You can load it using:
 
@@ -243,7 +243,7 @@ weights_dir = kagglehub.model_download('google/gemma-2/flax/gemma2-9b')
 ckpt_path = os.path.join(weights_dir, 'gemma2_9b_pt')
 ```
 
-For instance, to load the Gemma 3 4B model, you can use:
+To load the Gemma 3 4B model, you can use:
 
 ```python
 weights_dir = kagglehub.model_download('google/gemma-3/flax/gemma3-4b')

--- a/docs/guides/howto_reference.md
+++ b/docs/guides/howto_reference.md
@@ -217,9 +217,9 @@ You can read more about Penzai's conventions for layers in ["How to Think in Pen
 
 ## Loading Pretrained Models
 
-### Loading Gemma or Gemma 2
+### Loading Gemma or Gemma 2 or Gemma 3
 
-Penzai's Gemma implementation includes a conversion utility that converts the "Flax" model weights from Kaggle ([Gemma 1](https://www.kaggle.com/models/google/gemma), [Gemma 2](https://www.kaggle.com/models/google/gemma-2)) into the correct form. You can load it using:
+Penzai's Gemma implementation includes a conversion utility that converts the "Flax" model weights from Kaggle ([Gemma 1](https://www.kaggle.com/models/google/gemma), [Gemma 2](https://www.kaggle.com/models/google/gemma-2), [Gemma 3](https://www.kaggle.com/models/google/gemma-3)) into the correct form. You can load it using:
 
 ```python
 import kagglehub
@@ -236,11 +236,18 @@ flax_params_dict = checkpointer.restore(ckpt_path)
 model = variants.gemma.gemma_from_pretrained_checkpoint(flax_params_dict)
 ```
 
-To load Gemma 2, you can substitute the corresponding Kaggle model name and checkpoint path. For instance, to load the Gemma 2 9B model, you can use:
+To load Gemma 2/3, you can substitute the corresponding Kaggle model name and checkpoint path. For instance, to load the Gemma 2 9B model, you can use:
 
 ```python
 weights_dir = kagglehub.model_download('google/gemma-2/flax/gemma2-9b')
 ckpt_path = os.path.join(weights_dir, 'gemma2_9b_pt')
+```
+
+For instance, to load the Gemma 3 4B model, you can use:
+
+```python
+weights_dir = kagglehub.model_download('google/gemma-3/flax/gemma3-4b')
+ckpt_path = os.path.join(weights_dir, 'gemma3_4b_pt')
 ```
 
 See the "Model Variations" section on the Kaggle model pages for details about the names and paths for each checkpoint. (You may also need to create a Kaggle account and request access to each model before you can download the checkpoints.)

--- a/penzai/models/transformer/variants/gemma.py
+++ b/penzai/models/transformer/variants/gemma.py
@@ -269,13 +269,10 @@ def gemma_from_pretrained_checkpoint(
     num_layers = 0
     while f"layer_{num_layers}/mlp/linear" in params:
       num_layers += 1
-    if (
+    qk_norm = (
         "layer_0/attn/_query_norm" in params
         and "layer_0/attn/_key_norm" in params
-    ):
-      qk_norm = True
-    else:
-      qk_norm = False
+    )
     is_match = False
     for gemma_preset_name, kwargs in _GEMMA_PRESETS.items():
       if kwargs["num_decoder_blocks"] == num_layers:

--- a/penzai/models/transformer/variants/gemma.py
+++ b/penzai/models/transformer/variants/gemma.py
@@ -271,9 +271,10 @@ def gemma_from_pretrained_checkpoint(
     for gemma_preset_name, kwargs in _GEMMA_PRESETS.items():
       if kwargs["num_decoder_blocks"] == num_layers:
         if qk_norm and "use_qk_norm" in kwargs:
-          is_match = True
-          preset_name = gemma_preset_name
-          break
+          if kwargs["use_qk_norm"]:
+            is_match = True
+            preset_name = gemma_preset_name
+            break
         if (not qk_norm) and ("use_qk_norm" not in kwargs):
           is_match = True
           preset_name = gemma_preset_name

--- a/penzai/models/transformer/variants/gemma.py
+++ b/penzai/models/transformer/variants/gemma.py
@@ -34,7 +34,7 @@ from penzai.models.transformer import model_parts
 from penzai.models.transformer.variants import llamalike_common
 
 
-def make_attention_layers_types(
+def _make_attention_layers_types(
     pattern: tuple[llamalike_common.AttentionType, ...],
     *,
     num_layers: int,
@@ -128,7 +128,7 @@ _GEMMA_PRESETS = {
         embedding_dim=1152,
         projection_dim=256,
         mlp_hidden_dim=6 * 1152,
-        attention_type=make_attention_layers_types(
+        attention_type=_make_attention_layers_types(
             pattern=(llamalike_common.AttentionTypeSlidingWindowCausal(512),)
             * 5 + (llamalike_common.AttentionTypeGlobalCausal(),),
             num_layers=26,
@@ -136,8 +136,8 @@ _GEMMA_PRESETS = {
         use_qk_norm=True,
         use_post_attn_norm=True,
         use_post_ffw_norm=True,
+        rope_wavelength=1_000_000,
         local_rope_wavelength=10_000,
-        global_rope_wavelength=1_000_000,
     ),
     "gemma3_4b": dict(
         num_decoder_blocks=34,
@@ -147,7 +147,7 @@ _GEMMA_PRESETS = {
         embedding_dim=2560,
         projection_dim=256,
         mlp_hidden_dim=2560 * 8 // 2,
-        attention_type=make_attention_layers_types(
+        attention_type=_make_attention_layers_types(
             pattern=(llamalike_common.AttentionTypeSlidingWindowCausal(1024),)
             * 5 + (llamalike_common.AttentionTypeGlobalCausal(),),
             num_layers=34,
@@ -155,10 +155,9 @@ _GEMMA_PRESETS = {
         use_qk_norm=True,
         use_post_attn_norm=True,
         use_post_ffw_norm=True,
-        local_scale_factor=1.0,
         global_scale_factor=8.0,
+        rope_wavelength=1_000_000,
         local_rope_wavelength=10_000,
-        global_rope_wavelength=1_000_000,
     ),
     "gemma3_12b": dict(
         num_decoder_blocks=48,
@@ -168,7 +167,7 @@ _GEMMA_PRESETS = {
         embedding_dim=30 * 128,
         projection_dim=256,
         mlp_hidden_dim=8 * 30 * 128 // 2,
-        attention_type=make_attention_layers_types(
+        attention_type=_make_attention_layers_types(
             pattern=(llamalike_common.AttentionTypeSlidingWindowCausal(1024),)
             * 5 + (llamalike_common.AttentionTypeGlobalCausal(),),
             num_layers=48,
@@ -176,10 +175,9 @@ _GEMMA_PRESETS = {
         use_qk_norm=True,
         use_post_attn_norm=True,
         use_post_ffw_norm=True,
-        local_scale_factor=1.0,
         global_scale_factor=8.0,
+        rope_wavelength=1_000_000,
         local_rope_wavelength=10_000,
-        global_rope_wavelength=1_000_000,
     ),
     "gemma3_27b": dict(
         num_decoder_blocks=62,
@@ -191,18 +189,17 @@ _GEMMA_PRESETS = {
         mlp_hidden_dim=5376 * 8 // 2,
         # query scaling factor: 1/sqrt(embedding_dim / num_query_heads)
         query_scaling_factor=(5376 // 32) ** -0.5,
-        attention_type=make_attention_layers_types(
+        attention_type=_make_attention_layers_types(
             pattern=(llamalike_common.AttentionTypeSlidingWindowCausal(1024),)
             * 5 + (llamalike_common.AttentionTypeGlobalCausal(),),
-            num_layers=34,
+            num_layers=62,
         ),
         use_qk_norm=True,
         use_post_attn_norm=True,
         use_post_ffw_norm=True,
-        local_scale_factor=1.0,
         global_scale_factor=8.0,
+        rope_wavelength=1_000_000,
         local_rope_wavelength=10_000,
-        global_rope_wavelength=1_000_000,
     ),
 }
 _NEEDS_GATING_TRANSPOSE = {
@@ -299,7 +296,6 @@ def gemma_from_pretrained_checkpoint(
       **preset_kwargs,
       parameter_dtype=parameter_dtype,
       mlp_variant="geglu_approx",
-      rope_wavelength=10_000,
       tie_embedder_and_logits=True,
       activation_dtype=activation_dtype,
       use_layer_stack=use_layer_stack,

--- a/penzai/models/transformer/variants/gemma.py
+++ b/penzai/models/transformer/variants/gemma.py
@@ -316,16 +316,12 @@ def gemma_from_pretrained_checkpoint(
       config, init_base_rng=None, name="transformer"
   )
   parameter_mapping = {
-      "embedder.embeddings": (
-          pz.nx.NamedArray.wrap(params["embedder"]["input_embedding"]).tag(
-              "vocabulary", "embedding"
-          )
-      ),
-      "final_norm/scale.weights": (
-          pz.nx.NamedArray.wrap(1 + params["final_norm"]["scale"]).tag(
-              "embedding"
-          )
-      ),
+      "embedder.embeddings": pz.nx.NamedArray.wrap(
+          params["embedder"]["input_embedding"]
+      ).tag("vocabulary", "embedding"),
+      "final_norm/scale.weights": pz.nx.NamedArray.wrap(
+          1 + params["final_norm"]["scale"]
+      ).tag("embedding"),
   }
 
   all_block_params = []

--- a/penzai/models/transformer/variants/gemma.py
+++ b/penzai/models/transformer/variants/gemma.py
@@ -130,8 +130,12 @@ _GEMMA_PRESETS = {
         mlp_hidden_dim=6 * 1152,
         attention_type=_make_attention_layers_types(
             pattern=(llamalike_common.AttentionTypeSlidingWindowCausal(512),)
-            * 5 + (llamalike_common.AttentionTypeGlobalCausal(),),
+            * 5
+            + (
+                llamalike_common.AttentionTypeGlobalCausal(),
+            ),
             num_layers=26,
+
         ),
         use_qk_norm=True,
         use_post_attn_norm=True,
@@ -149,8 +153,12 @@ _GEMMA_PRESETS = {
         mlp_hidden_dim=2560 * 8 // 2,
         attention_type=_make_attention_layers_types(
             pattern=(llamalike_common.AttentionTypeSlidingWindowCausal(1024),)
-            * 5 + (llamalike_common.AttentionTypeGlobalCausal(),),
+            * 5
+            + (
+                llamalike_common.AttentionTypeGlobalCausal(),
+            ),
             num_layers=34,
+
         ),
         use_qk_norm=True,
         use_post_attn_norm=True,
@@ -169,8 +177,12 @@ _GEMMA_PRESETS = {
         mlp_hidden_dim=8 * 30 * 128 // 2,
         attention_type=_make_attention_layers_types(
             pattern=(llamalike_common.AttentionTypeSlidingWindowCausal(1024),)
-            * 5 + (llamalike_common.AttentionTypeGlobalCausal(),),
+            * 5
+            + (
+                llamalike_common.AttentionTypeGlobalCausal(),
+            ),
             num_layers=48,
+
         ),
         use_qk_norm=True,
         use_post_attn_norm=True,
@@ -191,8 +203,12 @@ _GEMMA_PRESETS = {
         query_scaling_factor=(5376 // 32) ** -0.5,
         attention_type=_make_attention_layers_types(
             pattern=(llamalike_common.AttentionTypeSlidingWindowCausal(1024),)
-            * 5 + (llamalike_common.AttentionTypeGlobalCausal(),),
+            * 5
+            + (
+                llamalike_common.AttentionTypeGlobalCausal(),
+            ),
             num_layers=62,
+
         ),
         use_qk_norm=True,
         use_post_attn_norm=True,
@@ -220,8 +236,16 @@ def gemma_from_pretrained_checkpoint(
     upcast_activations_to_float32: bool = False,
     use_layer_stack: bool = False,
     preset_name: Literal[
-        "gemma_2b", "gemma_7b", "gemma2_2b", "gemma2_9b", "gemma2_27b",
-        "gemma3_1b", "gemma3_4b", "gemma3_12b", "gemma3_27b", "auto"
+        "gemma_2b",
+        "gemma_7b",
+        "gemma2_2b",
+        "gemma2_9b",
+        "gemma2_27b",
+        "gemma3_1b",
+        "gemma3_4b",
+        "gemma3_12b",
+        "gemma3_27b",
+        "auto",
     ] = "auto",
 ) -> model_parts.TransformerLM:
   """Builds a Gemma model from a pretrained checkpoint.

--- a/penzai/models/transformer/variants/gemma.py
+++ b/penzai/models/transformer/variants/gemma.py
@@ -131,11 +131,8 @@ _GEMMA_PRESETS = {
         attention_type=_make_attention_layers_types(
             pattern=(llamalike_common.AttentionTypeSlidingWindowCausal(512),)
             * 5
-            + (
-                llamalike_common.AttentionTypeGlobalCausal(),
-            ),
+            + (llamalike_common.AttentionTypeGlobalCausal(),),
             num_layers=26,
-
         ),
         use_qk_norm=True,
         use_post_attn_norm=True,
@@ -154,11 +151,8 @@ _GEMMA_PRESETS = {
         attention_type=_make_attention_layers_types(
             pattern=(llamalike_common.AttentionTypeSlidingWindowCausal(1024),)
             * 5
-            + (
-                llamalike_common.AttentionTypeGlobalCausal(),
-            ),
+            + (llamalike_common.AttentionTypeGlobalCausal(),),
             num_layers=34,
-
         ),
         use_qk_norm=True,
         use_post_attn_norm=True,
@@ -178,11 +172,8 @@ _GEMMA_PRESETS = {
         attention_type=_make_attention_layers_types(
             pattern=(llamalike_common.AttentionTypeSlidingWindowCausal(1024),)
             * 5
-            + (
-                llamalike_common.AttentionTypeGlobalCausal(),
-            ),
+            + (llamalike_common.AttentionTypeGlobalCausal(),),
             num_layers=48,
-
         ),
         use_qk_norm=True,
         use_post_attn_norm=True,
@@ -204,11 +195,8 @@ _GEMMA_PRESETS = {
         attention_type=_make_attention_layers_types(
             pattern=(llamalike_common.AttentionTypeSlidingWindowCausal(1024),)
             * 5
-            + (
-                llamalike_common.AttentionTypeGlobalCausal(),
-            ),
+            + (llamalike_common.AttentionTypeGlobalCausal(),),
             num_layers=62,
-
         ),
         use_qk_norm=True,
         use_post_attn_norm=True,
@@ -328,12 +316,16 @@ def gemma_from_pretrained_checkpoint(
       config, init_base_rng=None, name="transformer"
   )
   parameter_mapping = {
-      "embedder.embeddings": pz.nx.NamedArray.wrap(
-          params["embedder"]["input_embedding"]
-      ).tag("vocabulary", "embedding"),
-      "final_norm/scale.weights": pz.nx.NamedArray.wrap(
-          1 + params["final_norm"]["scale"]
-      ).tag("embedding"),
+      "embedder.embeddings": (
+          pz.nx.NamedArray.wrap(params["embedder"]["input_embedding"]).tag(
+              "vocabulary", "embedding"
+          )
+      ),
+      "final_norm/scale.weights": (
+          pz.nx.NamedArray.wrap(1 + params["final_norm"]["scale"]).tag(
+              "embedding"
+          )
+      ),
   }
 
   all_block_params = []

--- a/penzai/models/transformer/variants/gemma.py
+++ b/penzai/models/transformer/variants/gemma.py
@@ -14,13 +14,14 @@
 
 """The Gemma architecture transformer variant.
 
-Supports both the Gemma 1 and Gemma 2 architectures. Based on the Flax
-reference implementation at https://github.com/google-deepmind/gemma.
+Supports all the Gemma 1, Gemma 2 and Gemma 3 architectures. Based on the
+Flax reference implementation at https://github.com/google-deepmind/gemma.
 
 See the Gemma technical reports for more information:
 
 * Gemma 1: https://arxiv.org/abs/2403.08295
 * Gemma 2: https://arxiv.org/abs/2408.00118
+* Gemma 3: https://arxiv.org/abs/2503.19786
 """
 
 from __future__ import annotations
@@ -105,6 +106,102 @@ _GEMMA_PRESETS = {
         final_logit_softcap=30.0,
         attn_logits_soft_cap=50.0,
     ),
+    "gemma3_1b": dict(
+        num_decoder_blocks=26,
+        vocab_size=262_144,
+        num_kv_heads=1,
+        query_head_multiplier=4,
+        embedding_dim=1152,
+        projection_dim=256,
+        mlp_hidden_dim=6*1152,
+        attention_type=(
+            llamalike_common.AttentionTypeSlidingWindowCausal(512),
+            llamalike_common.AttentionTypeSlidingWindowCausal(512),
+            llamalike_common.AttentionTypeSlidingWindowCausal(512),
+            llamalike_common.AttentionTypeSlidingWindowCausal(512),
+            llamalike_common.AttentionTypeSlidingWindowCausal(512),
+            llamalike_common.AttentionTypeGlobalCausal(),
+        ),
+        use_qk_norm=True,
+        use_post_attn_norm=True,
+        use_post_ffw_norm=True,
+        local_rope_wavelength=10_000,
+        global_rope_wavelength=1_000_000,
+    ),
+    "gemma3_4b": dict(
+        num_decoder_blocks=34,
+        vocab_size=262_144,
+        num_kv_heads=4,
+        query_head_multiplier=2,
+        embedding_dim=2560,
+        projection_dim=256,
+        mlp_hidden_dim=2560 * 8 // 2,
+        attention_type=(
+            llamalike_common.AttentionTypeSlidingWindowCausal(1024),
+            llamalike_common.AttentionTypeSlidingWindowCausal(1024),
+            llamalike_common.AttentionTypeSlidingWindowCausal(1024),
+            llamalike_common.AttentionTypeSlidingWindowCausal(1024),
+            llamalike_common.AttentionTypeSlidingWindowCausal(1024),
+            llamalike_common.AttentionTypeGlobalCausal(),
+        ),
+        use_qk_norm=True,
+        use_post_attn_norm=True,
+        use_post_ffw_norm=True,
+        local_scale_factor=1.0,
+        global_scale_factor=8.0,
+        local_rope_wavelength=10_000,
+        global_rope_wavelength=1_000_000,
+    ),
+    "gemma3_12b": dict(
+        num_decoder_blocks=48,
+        vocab_size=262_144,
+        num_kv_heads=8,
+        query_head_multiplier=2,
+        embedding_dim=30 * 128,
+        projection_dim=256,
+        mlp_hidden_dim=8 * 30 * 128 // 2,
+        attention_type=(
+            llamalike_common.AttentionTypeSlidingWindowCausal(1024),
+            llamalike_common.AttentionTypeSlidingWindowCausal(1024),
+            llamalike_common.AttentionTypeSlidingWindowCausal(1024),
+            llamalike_common.AttentionTypeSlidingWindowCausal(1024),
+            llamalike_common.AttentionTypeSlidingWindowCausal(1024),
+            llamalike_common.AttentionTypeGlobalCausal(),
+        ),
+        use_qk_norm=True,
+        use_post_attn_norm=True,
+        use_post_ffw_norm=True,
+        local_scale_factor=1.0,
+        global_scale_factor=8.0,
+        local_rope_wavelength=10_000,
+        global_rope_wavelength=1_000_000,
+    ),
+    "gemma3_27b": dict(
+        num_decoder_blocks=62,
+        vocab_size=262_144,
+        num_kv_heads=16,
+        query_head_multiplier=2,
+        embedding_dim=5376,
+        projection_dim=128,
+        mlp_hidden_dim=5376 * 8 // 2,
+        # query scaling factor: 1/sqrt(embedding_dim / num_query_heads)
+        query_scaling_factor=(5376 // 32) ** -0.5,
+        attention_type=(
+            llamalike_common.AttentionTypeSlidingWindowCausal(1024),
+            llamalike_common.AttentionTypeSlidingWindowCausal(1024),
+            llamalike_common.AttentionTypeSlidingWindowCausal(1024),
+            llamalike_common.AttentionTypeSlidingWindowCausal(1024),
+            llamalike_common.AttentionTypeSlidingWindowCausal(1024),
+            llamalike_common.AttentionTypeGlobalCausal(),
+        ),
+        use_qk_norm=True,
+        use_post_attn_norm=True,
+        use_post_ffw_norm=True,
+        local_scale_factor=1.0,
+        global_scale_factor=8.0,
+        local_rope_wavelength=10_000,
+        global_rope_wavelength=1_000_000,
+    ),
 }
 _NEEDS_GATING_TRANSPOSE = {
     "gemma_2b": False,
@@ -112,16 +209,21 @@ _NEEDS_GATING_TRANSPOSE = {
     "gemma2_2b": False,
     "gemma2_9b": True,
     "gemma2_27b": True,
+    "gemma3_1b": True,
+    "gemma3_4b": True,
+    "gemma3_12b": True,
+    "gemma3_27b": True,
 }
 
 
 def gemma_from_pretrained_checkpoint(
     ckpt_params: dict[str, Any],
+    preset_name: Literal[
+        "gemma_2b", "gemma_7b", "gemma2_2b", "gemma2_9b", "gemma2_27b",
+        "gemma3_1b", "gemma3_4b", "gemma3_12b", "gemma3_27b",
+    ],
     upcast_activations_to_float32: bool = False,
     use_layer_stack: bool = False,
-    preset_name: Literal[
-        "gemma_2b", "gemma_7b", "gemma2_2b", "gemma2_9b", "gemma2_27b", "auto"
-    ] = "auto",
 ) -> model_parts.TransformerLM:
   """Builds a Gemma model from a pretrained checkpoint.
 
@@ -139,31 +241,16 @@ def gemma_from_pretrained_checkpoint(
 
   Args:
     ckpt_params: Nested dictionary of weights from the Gemma checkpoint.
+    preset_name: The name of the Gemma preset to use.
     upcast_activations_to_float32: Whether to cast activations to float32 when
       the model runs. This allows analyzing activations at higher precision
       without consuming additional memory for parameters.
     use_layer_stack: Whether to use a layer stack for the decoder blocks.
-    preset_name: Preset name, used to determine model config. If "auto", uses
-      the number of layers in the checkpoint to determine the configuration.
 
   Returns:
     A Transformer model containing the loaded parameters.
   """
   params = {k.removeprefix("transformer/"): v for k, v in ckpt_params.items()}
-
-  if preset_name == "auto":
-    num_layers = 0
-    while f"layer_{num_layers}/mlp/linear" in params:
-      num_layers += 1
-    preset_by_num_layers = {
-        kwargs["num_decoder_blocks"]: preset_name
-        for preset_name, kwargs in _GEMMA_PRESETS.items()
-    }
-    if num_layers not in preset_by_num_layers:
-      raise ValueError(
-          f"Could not determine preset for model with {num_layers} layers."
-      )
-    preset_name = preset_by_num_layers[num_layers]
 
   preset_kwargs = _GEMMA_PRESETS[preset_name]
   preset_needs_gating_transpose = _NEEDS_GATING_TRANSPOSE[preset_name]
@@ -207,6 +294,19 @@ def gemma_from_pretrained_checkpoint(
             1 + params[f"layer_{i}/pre_attention_norm"]["scale"]
         ).tag("embedding")
     )
+    # Add qk norm if needed
+    if config.use_qk_norm:
+      cur_block_params["attention/_query_norm/scale.weights"] = (
+          pz.nx.NamedArray.wrap(
+              1 + params[f"layer_{i}/attn/_query_norm"]["scale"]
+          ).tag("projection")
+      )
+      cur_block_params["attention/_key_norm/scale.weights"] = (
+          pz.nx.NamedArray.wrap(
+              1 + params[f"layer_{i}/attn/_key_norm"]["scale"]
+          ).tag("projection")
+      )
+
     if config.use_post_attn_norm:
       cur_block_params["post_attention_norm/scale.weights"] = (
           pz.nx.NamedArray.wrap(

--- a/penzai/models/transformer/variants/llamalike_common.py
+++ b/penzai/models/transformer/variants/llamalike_common.py
@@ -34,6 +34,7 @@ from collections.abc import Sequence
 import dataclasses
 import functools
 from typing import Any, Literal
+
 import jax
 import jax.numpy as jnp
 from penzai import pz
@@ -104,7 +105,7 @@ class LlamalikeTransformerConfig:
     use_layer_stack: Whether to stack the blocks together using a LayerStack.
     use_qk_norm: Whether to use QK normalization.
     global_scale_factor: Scale factor for the global RoPE layers (scale factor
-      for the local RoPE layers is set as 1.0 by default).      
+      for the local RoPE layers is set as 1.0 by default).
     local_rope_wavelength: Wavelength for the local RoPE layers. If None, local
       RoPE layers will use the same wavelength as global RoPE layers
       (config.rope_wavelength).
@@ -665,14 +666,18 @@ def llamalike_from_huggingface_model(
   converted = {k: jax.dlpack.from_dlpack(v) for k, v in state_dict.items()}
 
   parameter_mapping = {
-      "embedder.embeddings": pz.nx.NamedArray.wrap(
-          converted["model.embed_tokens.weight"]
-      ).tag("vocabulary", "embedding"),
-      "final_norm/scale.weights": pz.nx.NamedArray.wrap(
-          converted["model.norm.weight"]
-      ).tag("embedding"),
-      "lm_head.weights": pz.nx.NamedArray.wrap(converted["lm_head.weight"]).tag(
-          "vocabulary", "embedding"
+      "embedder.embeddings": (
+          pz.nx.NamedArray.wrap(converted["model.embed_tokens.weight"]).tag(
+              "vocabulary", "embedding"
+          )
+      ),
+      "final_norm/scale.weights": (
+          pz.nx.NamedArray.wrap(converted["model.norm.weight"]).tag("embedding")
+      ),
+      "lm_head.weights": (
+          pz.nx.NamedArray.wrap(converted["lm_head.weight"]).tag(
+              "vocabulary", "embedding"
+          )
       ),
   }
 

--- a/penzai/models/transformer/variants/llamalike_common.py
+++ b/penzai/models/transformer/variants/llamalike_common.py
@@ -666,18 +666,14 @@ def llamalike_from_huggingface_model(
   converted = {k: jax.dlpack.from_dlpack(v) for k, v in state_dict.items()}
 
   parameter_mapping = {
-      "embedder.embeddings": (
-          pz.nx.NamedArray.wrap(converted["model.embed_tokens.weight"]).tag(
-              "vocabulary", "embedding"
-          )
-      ),
-      "final_norm/scale.weights": (
-          pz.nx.NamedArray.wrap(converted["model.norm.weight"]).tag("embedding")
-      ),
-      "lm_head.weights": (
-          pz.nx.NamedArray.wrap(converted["lm_head.weight"]).tag(
-              "vocabulary", "embedding"
-          )
+      "embedder.embeddings": pz.nx.NamedArray.wrap(
+          converted["model.embed_tokens.weight"]
+      ).tag("vocabulary", "embedding"),
+      "final_norm/scale.weights": pz.nx.NamedArray.wrap(
+          converted["model.norm.weight"]
+      ).tag("embedding"),
+      "lm_head.weights": pz.nx.NamedArray.wrap(converted["lm_head.weight"]).tag(
+          "vocabulary", "embedding"
       ),
   }
 

--- a/penzai/models/transformer/variants/llamalike_common.py
+++ b/penzai/models/transformer/variants/llamalike_common.py
@@ -103,8 +103,8 @@ class LlamalikeTransformerConfig:
     activation_dtype: Floating dtype to use for activations and KV cache tables.
     use_layer_stack: Whether to stack the blocks together using a LayerStack.
     use_qk_norm: Whether to use QK normalization.
-    global_scale_factor: Scale factor for the gloabl RoPE layers (scale factor
-      for the local RoPE layers is set as 1.0 by default).
+    global_scale_factor: Scale factor for the global RoPE layers (scale factor
+      for the local RoPE layers is set as 1.0 by default).      
     local_rope_wavelength: Wavelength for the local RoPE layers. If None, local
       RoPE layers will use the same wavelength as global RoPE layers
       (config.rope_wavelength).

--- a/penzai/nn/embeddings.py
+++ b/penzai/nn/embeddings.py
@@ -225,11 +225,18 @@ class ApplyRoPE(layer_base.Layer):
       each token in the sequence. This side input should be provided as an
       integer array that is broadcastable with the input, and which does NOT
       include the embedding axis.
+    # NOTE: add extra arguments to support Gemma3 models.
+    scale_factor: The scale factor to use for the positional embeddings.
   """
 
   embedding_axis: str = dataclasses.field(metadata={"pytree_node": False})
   max_wavelength: float = dataclasses.field(metadata={"pytree_node": False})
   positions_input_name: str = dataclasses.field(metadata={"pytree_node": False})
+  # NOTE: add extra arguments to support Gemma3 models.
+  scale_factor: float = dataclasses.field(
+      default=1.0,
+      metadata={"pytree_node": False},
+  )
 
   def _apply_1d(self, input_slice: jax.Array, position: jax.Array) -> jax.Array:
     """Apply RoPE to a one-dimensional JAX array."""
@@ -242,6 +249,10 @@ class ApplyRoPE(layer_base.Layer):
     # Since we're assuming `timescale` is a vector and `position` is a scalar,
     # we don't need any axis alignment.
     sinusoid_inp = position / timescale
+    # NOTE: add extra arguments to support Gemma3 models.
+    if self.scale_factor < 1.0:
+      raise ValueError("scale_factor must be >= 1.0, got {scale_factor")
+    sinusoid_inp = sinusoid_inp / self.scale_factor
     sin = jnp.sin(sinusoid_inp)
     cos = jnp.cos(sinusoid_inp)
     first_half, second_half = jnp.split(input_slice, 2)
@@ -298,12 +309,19 @@ class ApplyRoPEToSubset(layer_base.Layer):
       each token in the sequence. This side input should be provided as an
       integer array that is broadcastable with the input, and which does NOT
       include the embedding axis.
+    # NOTE: add extra arguments to support Gemma3 models.
+    scale_factor: The scale factor to use for the positional embeddings.
   """
 
   embedding_axis: str = dataclasses.field(metadata={"pytree_node": False})
   max_wavelength: float = dataclasses.field(metadata={"pytree_node": False})
   rope_subset_size: int = dataclasses.field(metadata={"pytree_node": False})
   positions_input_name: str = dataclasses.field(metadata={"pytree_node": False})
+  # NOTE: add extra arguments to support Gemma3 models.
+  scale_factor: float = dataclasses.field(
+      default=1.0,
+      metadata={"pytree_node": False},
+  )
 
   def __call__(
       self, inputs: named_axes.NamedArray, **side_inputs
@@ -319,6 +337,7 @@ class ApplyRoPEToSubset(layer_base.Layer):
         embedding_axis=self.embedding_axis,
         max_wavelength=self.max_wavelength,
         positions_input_name=self.positions_input_name,
+        scale_factor=self.scale_factor,
     )
     rotated_result = rotator(rotary_input, **side_inputs)
     return named_axes.concatenate(

--- a/penzai/nn/embeddings.py
+++ b/penzai/nn/embeddings.py
@@ -225,14 +225,13 @@ class ApplyRoPE(layer_base.Layer):
       each token in the sequence. This side input should be provided as an
       integer array that is broadcastable with the input, and which does NOT
       include the embedding axis.
-    # NOTE: add extra arguments to support Gemma3 models.
-    scale_factor: The scale factor to use for the positional embeddings.
+    scale_factor: The scale factor to use for the positional embeddings (used by
+      Gemma3 models).
   """
 
   embedding_axis: str = dataclasses.field(metadata={"pytree_node": False})
   max_wavelength: float = dataclasses.field(metadata={"pytree_node": False})
   positions_input_name: str = dataclasses.field(metadata={"pytree_node": False})
-  # NOTE: add extra arguments to support Gemma3 models.
   scale_factor: float = dataclasses.field(
       default=1.0,
       metadata={"pytree_node": False},
@@ -249,9 +248,8 @@ class ApplyRoPE(layer_base.Layer):
     # Since we're assuming `timescale` is a vector and `position` is a scalar,
     # we don't need any axis alignment.
     sinusoid_inp = position / timescale
-    # NOTE: add extra arguments to support Gemma3 models.
     if self.scale_factor < 1.0:
-      raise ValueError("scale_factor must be >= 1.0, got {scale_factor")
+      raise ValueError("scale_factor must be >= 1.0, got {scale_factor}")
     sinusoid_inp = sinusoid_inp / self.scale_factor
     sin = jnp.sin(sinusoid_inp)
     cos = jnp.cos(sinusoid_inp)
@@ -309,15 +307,14 @@ class ApplyRoPEToSubset(layer_base.Layer):
       each token in the sequence. This side input should be provided as an
       integer array that is broadcastable with the input, and which does NOT
       include the embedding axis.
-    # NOTE: add extra arguments to support Gemma3 models.
-    scale_factor: The scale factor to use for the positional embeddings.
+    scale_factor: The scale factor to use for the positional embeddings (used by
+      Gemma 3 models).
   """
 
   embedding_axis: str = dataclasses.field(metadata={"pytree_node": False})
   max_wavelength: float = dataclasses.field(metadata={"pytree_node": False})
   rope_subset_size: int = dataclasses.field(metadata={"pytree_node": False})
   positions_input_name: str = dataclasses.field(metadata={"pytree_node": False})
-  # NOTE: add extra arguments to support Gemma3 models.
   scale_factor: float = dataclasses.field(
       default=1.0,
       metadata={"pytree_node": False},


### PR DESCRIPTION
This PR extends the codebase of penzai to support gemma3 models. The key changes are as follows: 

- Add parameters `use_qk_norm`, `local_scale_factor`, `global_scale_factor`, `local_rope_wavelength`, `global_rope_wavelength`, to `llamalike_common.py`.
- Add function `_query_norm` and `_key_norm` in `llamalike_common.py`
- Add extra arguments `scale_factor` to `pz.nn.ApplyRoPE` in `nn/embeddings.py`
- Add parameters for the gemma3 models to `gemma.py`.